### PR TITLE
"upcasing" some fields.

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -54,7 +54,7 @@ module OFX
         OFX::Account.new({
           :bank_id      => html.search("bankacctfrom > bankid").inner_text,
           :id           => html.search("bankacctfrom > acctid").inner_text,
-          :type         => ACCOUNT_TYPES[html.search("bankacctfrom > accttype").inner_text],
+          :type         => ACCOUNT_TYPES[html.search("bankacctfrom > accttype").inner_text.to_s.upcase],
           :transactions => build_transactions,
           :balance      => build_balance,
           :currency     => html.search("bankmsgsrsv1 > stmttrnrs > stmtrs > curdef").inner_text
@@ -83,7 +83,7 @@ module OFX
       end
 
       def build_type(element)
-        TRANSACTION_TYPES[element.search("trntype").inner_text]
+        TRANSACTION_TYPES[element.search("trntype").inner_text.to_s.upcase]
       end
 
       def build_amount(element)


### PR DESCRIPTION
Hi Nando. 

It turns out that some ofx files have "Checking" instead of "CHECKING". I think it is a good idea to "upcase" these fields so we can find the right "type" for both account and transactions.

---- commit message-----
Ensure that we get the right account type by upcasing the accttype inner_text. 
Ensure that we get the right transaction type by upcasing the trntype inner_text.

[]s
