### PR TITLE
Switch to byebug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,26 +7,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.0.9)
-    columnize (0.3.6)
-    debugger (1.6.1)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.3)
+    byebug (2.7.0)
+      columnize (~> 0.3)
+      debugger-linecache (~> 1.2)
+    coderay (1.1.0)
+    columnize (0.8.9)
     debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.3)
     diff-lcs (1.1.3)
     method_source (0.8.2)
     mini_portile (0.5.1)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
-    pry (0.9.12.2)
-      coderay (~> 1.0.5)
+    pry (0.9.12.6)
+      coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    pry-debugger (0.2.2)
-      debugger (~> 1.3)
-      pry (~> 0.9.10)
+    pry-byebug (1.3.2)
+      byebug (~> 2.7)
+      pry (~> 0.9.12)
     rake (10.1.0)
     rspec (2.7.0)
       rspec-core (~> 2.7.0)
@@ -36,14 +34,13 @@ GEM
     rspec-expectations (2.7.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.7.0)
-    slop (3.4.6)
+    slop (3.5.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   ofx!
-  pry
-  pry-debugger
+  pry-byebug
   rake
   rspec (~> 2.7)

--- a/ofx.gemspec
+++ b/ofx.gemspec
@@ -29,6 +29,5 @@ TXT
   s.add_dependency "nokogiri"
   s.add_development_dependency "rspec", "~> 2.7"
   s.add_development_dependency "rake"
-  s.add_development_dependency "pry"
-  s.add_development_dependency "pry-debugger"
+  s.add_development_dependency "pry-byebug"
 end


### PR DESCRIPTION
debugger dropped ruby >2 support.

For ruby versions >2 is recommended [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug)
All specs pass

https://github.com/cldwalker/debugger/issues/125
