### PR TITLE
Support multiple accounts per file

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -22,8 +22,13 @@ module OFX
         @html = Nokogiri::HTML.parse(body)
       end
 
+      def accounts
+        @accounts ||= html.search("stmttrnrs, ccstmttrnrs").collect { |node| build_account(node) }
+      end
+
+      # DEPRECATED: kept for legacy support
       def account
-        @account ||= build_account
+        @account ||= build_account(html.search("stmttrnrs, ccstmttrnrs").first)
       end
 
       def sign_on
@@ -49,16 +54,15 @@ module OFX
       end
 
       private
-      def build_account
+      def build_account(node)
         OFX::Account.new({
-          :bank_id           => html.search("bankacctfrom > bankid").inner_text,
-          :id                => html.search("bankacctfrom > acctid, ccacctfrom > acctid").inner_text,
-          :type              => ACCOUNT_TYPES[html.search("bankacctfrom > accttype").inner_text.to_s.upcase],
-          :transactions      => build_transactions,
-          :balance           => build_balance,
-          :available_balance => build_available_balance,
-          :currency          => html.search("bankmsgsrsv1 > stmttrnrs > stmtrs > curdef, " +
-                                            "creditcardmsgsrsv1 > ccstmttrnrs > ccstmtrs > curdef").inner_text
+          :bank_id           => node.search("bankacctfrom > bankid").inner_text,
+          :id                => node.search("bankacctfrom > acctid, ccacctfrom > acctid").inner_text,
+          :type              => ACCOUNT_TYPES[node.search("bankacctfrom > accttype").inner_text.to_s.upcase],
+          :transactions      => build_transactions(node),
+          :balance           => build_balance(node),
+          :available_balance => build_available_balance(node),
+          :currency          => node.search("stmtrs > curdef, ccstmtrs > curdef").inner_text
         })
       end
 
@@ -70,8 +74,8 @@ module OFX
         })
       end
 
-      def build_transactions
-        html.search("banktranlist > stmttrn").collect do |element|
+      def build_transactions(node)
+        node.search("banktranlist > stmttrn").collect do |element|
           build_transaction(element)
         end
       end
@@ -109,24 +113,24 @@ module OFX
         Time.parse(date)
       end
 
-      def build_balance
-        amount = html.search("ledgerbal > balamt").inner_text.to_f
+      def build_balance(node)
+        amount = node.search("ledgerbal > balamt").inner_text.to_f
 
         OFX::Balance.new({
           :amount => amount,
           :amount_in_pennies => (amount * 100).to_i,
-          :posted_at => build_date(html.search("ledgerbal > dtasof").inner_text)
+          :posted_at => build_date(node.search("ledgerbal > dtasof").inner_text)
         })
       end
 
-      def build_available_balance
-        if html.search("availbal").size > 0
-          amount = html.search("availbal > balamt").inner_text.to_f
+      def build_available_balance(node)
+        if node.search("availbal").size > 0
+          amount = node.search("availbal > balamt").inner_text.to_f
 
           OFX::Balance.new({
             :amount => amount,
             :amount_in_pennies => (amount * 100).to_i,
-            :posted_at => build_date(html.search("availbal > dtasof").inner_text)
+            :posted_at => build_date(node.search("availbal > dtasof").inner_text)
           })
         else
           return nil

--- a/spec/ofx/ofx211_spec.rb
+++ b/spec/ofx/ofx211_spec.rb
@@ -26,16 +26,16 @@ describe OFX::Parser::OFX211 do
     @parser.sign_on.should be_a_kind_of(OFX::SignOn)
   end
 
-  context "transactions" do
-    before do
-      @transactions = @parser.account.transactions
-    end
+  it "should set accounts" do
+    @parser.accounts.size.should == 2
+  end
 
+  context "transactions" do
     # Test file contains only three transactions. Let's just check
     # them all.
     context "first" do
       before do
-        @t = @transactions[0]
+        @t = @parser.accounts[0].transactions[0]
       end
 
       it "should contain the correct values" do
@@ -49,7 +49,7 @@ describe OFX::Parser::OFX211 do
 
     context "second" do
       before do
-        @t = @transactions[1]
+        @t = @parser.accounts[1].transactions[0]
       end
       
       it "should contain the correct values" do
@@ -63,7 +63,7 @@ describe OFX::Parser::OFX211 do
     
     context "third" do
       before do
-        @t = @transactions[2]
+        @t = @parser.accounts[1].transactions[1]
       end
       
       it "should contain the correct values" do


### PR DESCRIPTION
Implements #9 by iterating over `(cc)stmttrnrs` nodes, and scoping searches to their child nodes.

Breaking change: the library previously considered all transactions to belong to a single account (whatever if the file contained multiple ones). This obviously has changed. The v211 fixture is a good example of that, because it actually contains 2 accounts (1 bank and 1 creditcard).