### PR TITLE
Add Time Zone handling

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -104,11 +104,23 @@ module OFX
         to_decimal(element.search("trnamt").inner_text)
       end
 
+      # Input format is `YYYYMMDDHHMMSS.XXX[gmt offset[:tz name]]`
       def build_date(date)
-        _, year, month, day, hour, minutes, seconds = *date.match(/(\d{4})(\d{2})(\d{2})(?:(\d{2})(\d{2})(\d{2}))?/)
+        tz_pattern = /(?:\[([+-]?\d{1,4})\:\S{3}\])?\z/
 
-        date = "#{year}-#{month}-#{day} "
-        date << "#{hour}:#{minutes}:#{seconds}" if hour && minutes && seconds
+        # Timezone offset handling
+        date.sub!(tz_pattern, '')
+        offset = Regexp.last_match(1)
+
+        if offset
+          # Offset padding
+          _, hours, mins = *offset.match(/\A([+-]?\d{1,2})(\d{0,2})?\z/)
+          offset = "%+03d%02d" % [hours.to_i, mins.to_i]
+        else
+          offset = "+0000"
+        end
+
+        date << " #{offset}"
 
         Time.parse(date)
       end

--- a/spec/ofx/account_spec.rb
+++ b/spec/ofx/account_spec.rb
@@ -38,7 +38,7 @@ describe OFX::Account do
     end
 
     it "should return balance date" do
-      @account.balance.posted_at.should == Time.parse("2009-11-01")
+      @account.balance.posted_at.should == Time.gm(2009,11,1)
     end
 
     context "available_balance" do
@@ -51,7 +51,7 @@ describe OFX::Account do
       end
 
       it "should return available balance date" do
-        @account.available_balance.posted_at.should == Time.parse("2009-11-01")
+        @account.available_balance.posted_at.should == Time.gm(2009,11,1)
       end
 
       it "should return nil if AVAILBAL not found" do

--- a/spec/ofx/ofx102_spec.rb
+++ b/spec/ofx/ofx102_spec.rb
@@ -42,5 +42,21 @@ describe OFX::Parser::OFX102 do
       transaction_type.downcase.to_sym.should equal OFX::Parser::OFX102::TRANSACTION_TYPES[transaction_type]
     end
   end
-  
+
+  describe "#build_date" do
+    context "without a Time Zone" do
+      it "should default to GMT" do
+        @parser.send(:build_date, "20170904").should == Time.gm(2017, 9, 4)
+        @parser.send(:build_date, "20170904082855").should == Time.gm(2017, 9, 4, 8, 28, 55)
+      end
+    end
+
+    context "with a Time Zone" do
+      it "should returns the correct date" do
+        @parser.send(:build_date, "20150507164333[-0300:BRT]").should == Time.new(2015, 5, 7, 16, 43, 33, "-03:00")
+        @parser.send(:build_date, "20180507120000[0:GMT]").should == Time.gm(2018, 5, 7, 12)
+        @parser.send(:build_date, "20170904082855[-3:GMT]").should == Time.new(2017, 9, 4, 8, 28, 55, "-03:00")
+      end
+    end
+  end
 end

--- a/spec/ofx/ofx211_spec.rb
+++ b/spec/ofx/ofx211_spec.rb
@@ -42,7 +42,7 @@ describe OFX::Parser::OFX211 do
         @t.amount.should == BigDecimal('-80')
         @t.fit_id.should == "219378"
         @t.memo.should be_empty
-        @t.posted_at.should == Time.parse("2005-08-24 08:00:00")
+        @t.posted_at.should == Time.parse("2005-08-24 08:00:00 +0000")
         @t.name.should == "FrogKick Scuba Gear"
       end
     end
@@ -56,7 +56,7 @@ describe OFX::Parser::OFX211 do
         @t.amount.should == BigDecimal('-23')
         @t.fit_id.should == "219867"
         @t.memo.should be_empty
-        @t.posted_at.should == Time.parse("2005-08-11 08:00:00")
+        @t.posted_at.should == Time.parse("2005-08-11 08:00:00 +0000")
         @t.name.should == "Interest Charge"
       end
     end
@@ -70,7 +70,7 @@ describe OFX::Parser::OFX211 do
         @t.amount.should == BigDecimal('350')
         @t.fit_id.should == "219868"
         @t.memo.should be_empty
-        @t.posted_at.should == Time.parse("2005-08-11 08:00:00")
+        @t.posted_at.should == Time.parse("2005-08-11 08:00:00 +0000")
         @t.name.should == "Payment - Thank You"
       end
     end

--- a/spec/ofx/transaction_spec.rb
+++ b/spec/ofx/transaction_spec.rb
@@ -37,7 +37,7 @@ describe OFX::Transaction do
     end
 
     it "should have date" do
-      @transaction.posted_at.should == Time.parse("2009-10-09 08:00:00")
+      @transaction.posted_at.should == Time.gm(2009,10,9,8)
     end
 
     it "should have type" do
@@ -75,7 +75,7 @@ describe OFX::Transaction do
     end
 
     it "should have date" do
-      @transaction.posted_at.should == Time.parse("2009-10-16 08:00:00")
+      @transaction.posted_at.should == Time.parse("2009-10-16 08:00:00 +0000")
     end
 
     it "should have type" do
@@ -101,7 +101,7 @@ describe OFX::Transaction do
     end
 
     it "should have date" do
-      @transaction.posted_at.should == Time.parse("2009-10-19 12:00:00")
+      @transaction.posted_at.should == Time.parse("2009-10-19 12:00:00 -0300")
     end
 
     it "should have type" do


### PR DESCRIPTION
I realised on our project that all times were parsed in the system time ignoring the Time Zone if it was present.

As per the specs the complete  format for dates, time and time zones is:
> YYYYMMDDHHMMSS.XXX [gmt offset[:tz name]]

The default timezone is GMT.

I don't like directly testing private method (`build_date`) but I figured it was the easier to test all possible cases.