### PR TITLE
Add extra account types

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -4,7 +4,10 @@ module OFX
       VERSION = "1.0.2"
 
       ACCOUNT_TYPES = {
-        "CHECKING" => :checking
+        "CHECKING" => :checking,
+        "SAVINGS"  => :savings,
+        "CREDITLINE" => :creditline,
+        "MONEYMRKT" => :moneymrkt
       }
 
       TRANSACTION_TYPES = [


### PR DESCRIPTION
As per the specs:

| Type | Description |
|--------|-----------------|
| CHECKING | Checking |
| SAVINGS | Savings |
| MONEYMRKT | Money Market |
| CREDITLINE | Line of credit |

Not sure if this is better:
```ruby
ACCOUNT_TYPES = {
  "CHECKING" => :checking,
  "SAVINGS"  => :savings,
  "CREDITLINE" => :credit_line, # or :line_of_credit
  "MONEYMRKT" => :money_market
}
```