### PR TITLE
Bump nokigiri to fix CVS issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,9 +15,9 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.1.3)
     method_source (0.8.2)
-    mini_portile2 (2.1.0)
-    nokogiri (1.7.1)
-      mini_portile2 (~> 2.1.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
@@ -46,4 +46,4 @@ DEPENDENCIES
   rspec (~> 2.7)
 
 BUNDLED WITH
-   1.14.6
+   1.16.4


### PR DESCRIPTION
Only a problem in development as the gemspec doesn't have any constraints on nokogiri version.