### PR TITLE
fix(warning): BigDecimal.new -> BigDecimal()

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -191,7 +191,7 @@ module OFX
       end
 
       def to_decimal(amount)
-        BigDecimal.new(amount.to_s.gsub(',', '.'))
+        BigDecimal(amount.to_s.gsub(',', '.'))
       end
     end
   end

--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -191,7 +191,7 @@ module OFX
       end
 
       def to_decimal(amount)
-        BigDecimal(amount.to_s.gsub(',', '.'))
+        BigDecimal(amount.to_s.tr(',', '.'))
       end
     end
   end


### PR DESCRIPTION
Ruby 2.6.0 throws the following error:

> warning: BigDecimal.new is deprecated; use BigDecimal() method instead.

This is fixed with the current commit