### PR TITLE
BigDecimal.new() -> BigDecimal() for Ruby 2.7

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -191,7 +191,7 @@ module OFX
       end
 
       def to_decimal(amount)
-        BigDecimal.new(amount.to_s.gsub(',', '.'))
+        BigDecimal(amount.to_s.gsub(',', '.'))
       end
     end
   end


### PR DESCRIPTION
Ruby 2.7 (BigDecimal 2) removes `BigDecimal.new()` in favor of `BigDecimal()`

I tested `BigDecimal()`on Ruby 2.0 and it worked correctly, but we might want to test on more versions.