### PR TITLE
Add currate inside transactions

### DIFF
--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -130,6 +130,7 @@ module OFX
           :check_number      => element.search("checknum").inner_text,
           :ref_number        => element.search("refnum").inner_text,
           :posted_at         => build_date(element.search("dtposted").inner_text),
+          :currency_currate  => element.search("currate").inner_text
           :occurred_at       => occurred_at,
           :type              => build_type(element),
           :sic               => element.search("sic").inner_text

--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -130,7 +130,7 @@ module OFX
           :check_number      => element.search("checknum").inner_text,
           :ref_number        => element.search("refnum").inner_text,
           :posted_at         => build_date(element.search("dtposted").inner_text),
-          :currency_currate  => element.search("currate").inner_text
+          :currency_currate  => element.search("currate").inner_text,
           :occurred_at       => occurred_at,
           :type              => build_type(element),
           :sic               => element.search("sic").inner_text

--- a/lib/ofx/transaction.rb
+++ b/lib/ofx/transaction.rb
@@ -10,6 +10,7 @@ module OFX
     attr_accessor :posted_at
     attr_accessor :occurred_at
     attr_accessor :ref_number
+    attr_accessor :currency_currate
     attr_accessor :type
     attr_accessor :sic
   end


### PR DESCRIPTION
Hi, first of all, this is an amazing repository and helped me a lot! Congratulation on this work. I from Brazil and realized some issues in values during US Dollar purchases importation. I wanted to retrieve the BR Real purchase value but the ofx file gave me only the US Dolar value. So, after analyzing the repo and the ofx file I've realized that could be possible to insert the US Dollar rate conversion information within transactions fields, and that's what I'm suggesting in this pull request. Thanks a lot for your help and for the possibility to contribute to the project! 