### PR TITLE
Fix RSpec test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,20 @@
 PATH
   remote: .
   specs:
-    ofx (0.3.2)
-      nokogiri
+    ofx (0.3.3)
+      nokogiri (~> 1.13.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (11.1.1)
-    coderay (1.1.2)
+    byebug (11.1.3)
     diff-lcs (1.5.0)
-    method_source (1.0.0)
-    mini_portile2 (2.7.1)
-    nokogiri (1.13.1)
-      mini_portile2 (~> 2.7.0)
+    mini_portile2 (2.8.0)
+    nokogiri (1.13.4)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    pry (0.13.0)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     racc (1.6.0)
-    rake (13.0.3)
+    rake (13.0.6)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -41,9 +33,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug (~> 11.1.3)
   ofx!
-  pry-byebug
-  rake
+  rake (~> 13.0.6)
   rspec (~> 3.10)
 
 BUNDLED WITH

--- a/lib/ofx/parser/ofx102.rb
+++ b/lib/ofx/parser/ofx102.rb
@@ -52,7 +52,7 @@ module OFX
 
       def self.parse_headers(header_text)
         # Change single CR's to LF's to avoid issues with some banks
-        header_text.gsub!(/\r(?!\n)/, '\n')
+        header_text.gsub!(/\r(?!\n)/, "\n")
 
         # Parse headers. When value is NONE, convert it to nil.
         headers = header_text.to_enum(:each_line).each_with_object({}) do |line, memo|

--- a/spec/ofx/ofx_parser_spec.rb
+++ b/spec/ofx/ofx_parser_spec.rb
@@ -101,15 +101,13 @@ describe OFX::Parser do
     end
 
     it "should parse headers with CR and without LF" do
+      header = %{OFXHEADER:100\rDATA:OFXSGML\rVERSION:102\rSECURITY:NONE\rENCODING:USASCII\rCHARSET:1252\rCOMPRESSION:NONE\rOLDFILEUID:NONE\rNEWFILEUID:NONE\r}
+      body   = open("spec/fixtures/sample.ofx").read.split(/<OFX>/, 2)[1]
+      ofx_with_carriage_return = header + "<OFX>" + body
+
       @ofx = OFX::Parser::Base.new(ofx_with_carriage_return)
       @ofx.headers.size.should be(9)
     end
-  end
-
-  def ofx_with_carriage_return
-    header = %{OFXHEADER:100\rDATA:OFXSGML\rVERSION:102\rSECURITY:NONE\rENCODING:USASCII\rCHARSET:1252\rCOMPRESSION:NONE\rOLDFILEUID:NONE\rNEWFILEUID:NONE\r}
-    body   = open("spec/fixtures/sample.ofx").read.split(/<OFX>/, 2)[1]
-    header + "<OFX>" + body
   end
 
   def ofx_2_example(version)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "ofx"
+require "byebug"
 
 RSpec::Matchers.define :have_key do |key|
   match do |hash|
@@ -6,4 +7,8 @@ RSpec::Matchers.define :have_key do |key|
     hash.keys.kind_of?(Array) &&
     hash.keys.include?(key)
   end
+end
+
+RSpec.configure do |c|
+  c.filter_run_when_matching :focus
 end


### PR DESCRIPTION
```ruby
Failures:

  1) OFX::Parser headers should parse headers with CR and without LF
     Failure/Error: raise OFX::UnsupportedFileError

     OFX::UnsupportedFileError:
       OFX::UnsupportedFileError
     # ./lib/ofx/parser.rb:27:in `initialize'
     # ./spec/ofx/ofx_parser_spec.rb:108:in `new'
     # ./spec/ofx/ofx_parser_spec.rb:108:in `block (3 levels) in <top (required)>'
```
