### PR TITLE
Set required_ruby_version and update supported OFX versions in gemspec

### DIFF
--- a/ofx.gemspec
+++ b/ofx.gemspec
@@ -8,10 +8,10 @@ Gem::Specification.new do |s|
   s.authors     = ['Nando Vieira', 'Anna Cruz']
   s.email       = ['fnando.vieira@gmail.com', 'anna.cruz@gmail.com']
   s.homepage    = 'http://rubygems.org/gems/ofx'
-  s.summary     = 'A simple OFX (Open Financial Exchange) parser built on top of Nokogiri. Currently supports OFX 102, 200 and 211.'
+  s.summary     = 'A simple OFX (Open Financial Exchange) parser built on top of Nokogiri. Currently supports OFX 100, 102, 103, 200, 202, 211 and 220.'
   s.description = <<~TXT
     A simple OFX (Open Financial Exchange) parser built on top of Nokogiri.
-    Currently supports OFX 102, 200 and 211.
+    Currently supports OFX 100, 102, 103, 200, 202, 211 and 220.
 
     Usage:
 
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.files         = Dir['lib/**/*.rb', 'spec/**/*.rb', 'README.rdoc', 'Rakefile']
   s.require_paths = ['lib']
   s.licenses      = ['MIT']
+  s.required_ruby_version = '>= 3.1.0'
 
   s.add_dependency 'nokogiri', '>= 1.13.1', '< 1.19.2'
   s.add_development_dependency 'byebug', '~> 11.1.3'


### PR DESCRIPTION
## Summary

- Declare `required_ruby_version >= 3.1.0` in the gemspec
- Update `summary` and `description` to list all OFX versions actually supported by the parser

## Background

### Minimum Ruby version

The project already transitively required Ruby >= 3.1.0 via Nokogiri 1.18.x, which declares that constraint explicitly. Adding `required_ruby_version` to the gemspec makes this requirement visible upfront — it appears on the gem's page on rubygems.org and causes RubyGems to reject installation immediately with a clear message, rather than failing later during dependency resolution.

### Supported OFX versions

The gemspec previously advertised support only for OFX 102, 200 and 211. However, `lib/ofx/parser.rb` has been routing a wider set of versions for some time:

| Versions | Parser used |
|----------|-------------|
| 100, 102, 103 | `OFX102` |
| 200, 202, 211, 220 | `OFX211` |

The summary and description now reflect all seven supported versions.

## Test plan

- [ ] All existing RSpec examples pass with no failures