### PR TITLE
chore: install Guard and Guard-RSpec for continuous test feedback

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,15 +11,60 @@ GEM
   specs:
     byebug (11.1.3)
     cgi (0.5.1)
+    coderay (1.1.3)
     diff-lcs (1.6.2)
     erb (4.0.4)
       cgi (>= 0.3.3)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    formatador (1.2.3)
+      reline
+    guard (2.20.1)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      logger (~> 1.6)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    io-console (0.8.2)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    lumberjack (1.4.2)
+    method_source (1.1.0)
     mini_portile2 (2.8.9)
+    nenv (0.3.0)
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.18.10-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.10-x86_64-linux-gnu)
+      racc (~> 1.4)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    pry (0.16.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      reline (>= 0.6.0)
     racc (1.8.1)
     rake (13.0.6)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    reline (0.6.3)
+      io-console (~> 0.5)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -33,17 +78,21 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.4)
+    shellany (0.0.1)
     stringio (3.1.9)
+    thor (1.5.0)
 
 PLATFORMS
-  arm64-darwin-24
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES
   byebug (~> 11.1.3)
+  guard (~> 2.20)
+  guard-rspec (~> 4.7)
   ofx!
   rake (~> 13.0.6)
   rspec (~> 3.10)
 
 BUNDLED WITH
-   2.3.3
+  4.0.8

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,14 @@
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+end

--- a/ofx.gemspec
+++ b/ofx.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug', '~> 11.1.3'
   s.add_development_dependency 'rake', '~> 13.0.6'
   s.add_development_dependency 'rspec', '~> 3.10'
+  s.add_development_dependency 'guard', '~> 2.20'
+  s.add_development_dependency 'guard-rspec', '~> 4.7'
   s.add_dependency 'erb', '~> 4.0.4'
   s.add_dependency 'stringio', '~> 3.1.7'
 end


### PR DESCRIPTION
## Summary

Installs Guard and Guard-RSpec as development dependencies, enabling automated test execution during development whenever source or spec files change.

### Changes

- **`ofx.gemspec`**: added `guard (~> 2.20)` and `guard-rspec (~> 4.7)` as development dependencies
- **`Guardfile`**: new file configuring Guard to watch `lib/` and `spec/` files and re-run RSpec on changes
- **`Gemfile.lock`**: updated after running `bundle install`

### How to use

```bash
bundle exec guard
```

Guard will start watching the project and automatically run the relevant specs whenever a file changes.

### Versions installed

| Gem | Version | Notes |
|-----|---------|-------|
| guard | 2.20.1 | Latest |
| guard-rspec | 4.7.3 | Latest (project in maintenance mode since 2016) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)