### PR TITLE
Fix RSpec test descriptions: migrate to present tense

### DIFF
--- a/spec/ofx/account_spec.rb
+++ b/spec/ofx/account_spec.rb
@@ -8,53 +8,53 @@ describe OFX::Account do
   end
 
   describe "account" do
-    it "should return currency" do
+    it "returns currency" do
       expect(@account.currency).to eql "BRL"
     end
 
-    it "should return bank id" do
+    it "returns bank id" do
       expect(@account.bank_id).to eql "0356"
     end
 
-    it "should return id" do
+    it "returns id" do
       expect(@account.id).to eql "03227113109"
     end
 
-    it "should return type" do
+    it "returns type" do
       expect(@account.type).to eql :checking
     end
 
-    it "should return transactions" do
+    it "returns transactions" do
       expect(@account.transactions).to be_a_kind_of(Array)
       expect(@account.transactions.size).to eql 36
     end
 
-    it "should return balance" do
+    it "returns balance" do
       expect(@account.balance.amount).to eql BigDecimal('598.44')
     end
 
-    it "should return balance in pennies" do
+    it "returns balance in pennies" do
       expect(@account.balance.amount_in_pennies).to eql 59844
     end
 
-    it "should return balance date" do
+    it "returns balance date" do
       expect(@account.balance.posted_at).to eql Time.gm(2009,11,1)
     end
 
     context "available_balance" do
-      it "should return available balance" do
+      it "returns available balance" do
         expect(@account.available_balance.amount).to eql BigDecimal('1555.99')
       end
 
-      it "should return available balance in pennies" do
+      it "returns available balance in pennies" do
         expect(@account.available_balance.amount_in_pennies).to eql 155599
       end
 
-      it "should return available balance date" do
+      it "returns available balance date" do
         expect(@account.available_balance.posted_at).to eql Time.gm(2009,11,1)
       end
 
-      it "should return nil if AVAILBAL not found" do
+      it "returns nil if AVAILBAL not found" do
         @ofx = OFX::Parser::Base.new("spec/fixtures/utf8.ofx")
         @parser = @ofx.parser
         @account = @parser.account
@@ -69,11 +69,11 @@ describe OFX::Account do
         @account = @parser.account
       end
 
-      it "should return id" do
+      it "returns id" do
         expect(@account.id).to eql "XXXXXXXXXXXX1111"
       end
 
-      it "should return currency" do
+      it "returns currency" do
         expect(@account.currency).to eql "USD"
       end
     end
@@ -84,7 +84,7 @@ describe OFX::Account do
         @account = @parser.account
       end
 
-      it "should return nil for date balance" do
+      it "returns nil for date balance" do
         expect(@account.balance.posted_at).to be_nil
       end
     end
@@ -94,10 +94,10 @@ describe OFX::Account do
         @ofx = OFX::Parser::Base.new("spec/fixtures/bradesco.ofx")
         @parser = @ofx.parser
       end
-      it "should not raise error when balance has date zero" do
+      it "does not raise error when balance has date zero" do
         expect { @parser.account.balance }.to_not raise_error
       end
-      it "should return NIL in balance.posted_at when balance date is zero" do
+      it "returns NIL in balance.posted_at when balance date is zero" do
         expect(@parser.account.balance.posted_at).to be_nil
       end
     end
@@ -109,20 +109,20 @@ describe OFX::Account do
         @account = @parser.account
       end
 
-      it "should return balance" do
+      it "returns balance" do
         expect(@account.balance.amount).to eql BigDecimal('348.29')
       end
 
-      it "should return balance in pennies" do
+      it "returns balance in pennies" do
         expect(@account.balance.amount_in_pennies).to eql 34829
       end
 
       context "available_balance" do
-        it "should return available balance" do
+        it "returns available balance" do
           expect(@account.available_balance.amount).to eql BigDecimal('2415.87')
         end
 
-        it "should return available balance in pennies" do
+        it "returns available balance in pennies" do
           expect(@account.available_balance.amount_in_pennies).to eql 241587
         end
       end

--- a/spec/ofx/ofx102_spec.rb
+++ b/spec/ofx/ofx102_spec.rb
@@ -6,37 +6,37 @@ describe OFX::Parser::OFX102 do
     @parser = @ofx.parser
   end
 
-  it "should have a version" do
+  it "has a version" do
     expect(OFX::Parser::OFX102::VERSION).to eql "1.0.2"
   end
 
-  it "should set headers" do
+  it "sets headers" do
     expect(@parser.headers).to eql @ofx.headers
   end
 
-  it "should trim trailing whitespace from headers" do
+  it "trims trailing whitespace from headers" do
     headers = OFX::Parser::OFX102.parse_headers("VERSION:102   ")
     expect(headers["VERSION"]).to eql "102"
   end
 
-  it "should set body" do
+  it "sets body" do
     expect(@parser.body).to eql @ofx.body
   end
 
-  it "should set account" do
+  it "sets account" do
     expect(@parser.account).to be_a_kind_of(OFX::Account)
   end
 
-  it "should set account" do
+  it "sets sign_on" do
     expect(@parser.sign_on).to be_a_kind_of(OFX::SignOn)
   end
 
-  it "should set statements" do
+  it "sets statements" do
     expect(@parser.statements.size).to eql 1
     expect(@parser.statements.first).to be_a_kind_of(OFX::Statement)
   end
 
-  it "should know about all transaction types" do
+  it "knows about all transaction types" do
     valid_types = [
       'CREDIT', 'DEBIT', 'INT', 'DIV', 'FEE', 'SRVCHG', 'DEP', 'ATM', 'POS', 'XFER',
       'CHECK', 'PAYMENT', 'CASH', 'DIRECTDEP', 'DIRECTDEBIT', 'REPEATPMT', 'OTHER', 'IN', 'OUT'
@@ -50,14 +50,14 @@ describe OFX::Parser::OFX102 do
 
   describe "#build_date" do
     context "without a Time Zone" do
-      it "should default to GMT" do
+      it "defaults to GMT" do
         expect(@parser.send(:build_date, "20170904")).to eql Time.gm(2017, 9, 4)
         expect(@parser.send(:build_date, "20170904082855")).to eql Time.gm(2017, 9, 4, 8, 28, 55)
       end
     end
 
     context "with a Time Zone" do
-      it "should returns the correct date" do
+      it "returns the correct date" do
         expect(@parser.send(:build_date, "20150507164333[-0300:BRT]")).to eql Time.new(2015, 5, 7, 16, 43, 33, "-03:00")
         expect(@parser.send(:build_date, "20180507120000[0:GMT]")).to eql Time.gm(2018, 5, 7, 12)
         expect(@parser.send(:build_date, "20170904082855[-3:GMT]")).to eql Time.new(2017, 9, 4, 8, 28, 55, "-03:00")

--- a/spec/ofx/ofx211_spec.rb
+++ b/spec/ofx/ofx211_spec.rb
@@ -6,31 +6,31 @@ describe OFX::Parser::OFX211 do
     @parser = @ofx.parser
   end
 
-  it "should have a version" do
+  it "has a version" do
     expect(OFX::Parser::OFX211::VERSION).to eql "2.1.1"
   end
 
-  it "should set headers" do
+  it "sets headers" do
     expect(@parser.headers).to eql @ofx.headers
   end
 
-  it "should set body" do
+  it "sets body" do
     expect(@parser.body).to eql @ofx.body
   end
 
-  it "should set account" do
+  it "sets account" do
     expect(@parser.account).to be_a_kind_of(OFX::Account)
   end
 
-  it "should set account" do
+  it "sets sign_on" do
     expect(@parser.sign_on).to be_a_kind_of(OFX::SignOn)
   end
 
-  it "should set accounts" do
+  it "sets accounts" do
     expect(@parser.accounts.size).to eql 2
   end
 
-  it "should set statements" do
+  it "sets statements" do
     expect(@parser.statements.size).to eql 2
     expect(@parser.statements.first).to be_a_kind_of(OFX::Statement)
   end
@@ -43,7 +43,7 @@ describe OFX::Parser::OFX211 do
         @t = @parser.accounts[0].transactions[0]
       end
 
-      it "should contain the correct values" do
+      it "contains the correct values" do
         expect(@t.amount).to eql BigDecimal('-80')
         expect(@t.fit_id).to eql "219378"
         expect(@t.memo).to be_empty
@@ -57,7 +57,7 @@ describe OFX::Parser::OFX211 do
         @t = @parser.accounts[1].transactions[0]
       end
 
-      it "should contain the correct values" do
+      it "contains the correct values" do
         expect(@t.amount).to eql BigDecimal('-23')
         expect(@t.fit_id).to eql "219867"
         expect(@t.memo).to be_empty
@@ -71,7 +71,7 @@ describe OFX::Parser::OFX211 do
         @t = @parser.accounts[1].transactions[1]
       end
 
-      it "should contain the correct values" do
+      it "contains the correct values" do
         expect(@t.amount).to eql BigDecimal('350')
         expect(@t.fit_id).to eql "219868"
         expect(@t.memo).to be_empty

--- a/spec/ofx/ofx_parser_spec.rb
+++ b/spec/ofx/ofx_parser_spec.rb
@@ -16,88 +16,88 @@ describe OFX::Parser do
     @ofx = OFX::Parser::Base.new("spec/fixtures/sample.ofx")
   end
 
-  it "should accept file path" do
+  it "accepts file path" do
     @ofx = OFX::Parser::Base.new("spec/fixtures/sample.ofx")
     expect(@ofx.content).not_to be_nil
   end
 
-  it "should accept file handler" do
+  it "accepts file handler" do
     file = open("spec/fixtures/sample.ofx")
     @ofx = OFX::Parser::Base.new(file)
     expect(@ofx.content).not_to be_nil
   end
 
-  it "should accept file content" do
+  it "accepts file content" do
     file = open("spec/fixtures/sample.ofx").read
     @ofx = OFX::Parser::Base.new(file)
     expect(@ofx.content).not_to be_nil
   end
 
-  it "should set content" do
+  it "sets content" do
     expect(@ofx.content).to eql open("spec/fixtures/sample.ofx").read
   end
 
-  it "should work with UTF8 and Latin1 encodings" do
+  it "works with UTF8 and Latin1 encodings" do
     @ofx = OFX::Parser::Base.new("spec/fixtures/utf8.ofx")
     expect(@ofx.content).to eql open("spec/fixtures/utf8.ofx").read
   end
 
-  it "should set body" do
+  it "sets body" do
     expect(@ofx.body).not_to be_nil
   end
 
-  it "should raise exception when trying to parse an unsupported OFX version" do
+  it "raises exception when trying to parse an unsupported OFX version" do
     expect {
       OFX::Parser::Base.new("spec/fixtures/invalid_version.ofx")
     }.to raise_error(OFX::UnsupportedFileError)
   end
 
-  it "should raise exception when trying to parse an invalid file" do
+  it "raises exception when trying to parse an invalid file" do
     expect {
       OFX::Parser::Base.new("spec/fixtures/avatar.gif")
     }.to raise_error(OFX::UnsupportedFileError)
   end
 
-  it "should use 102 parser to parse version 100 ofx files" do
+  it "uses 102 parser to parse version 100 ofx files" do
     expect(OFX::Parser::OFX102).to receive(:new).and_return('ofx-102-parser')
 
     ofx = OFX::Parser::Base.new(ofx_example_to('100'))
     expect(ofx.parser).to eql 'ofx-102-parser'
   end
 
-  it "should use 102 parser to parse version 102 ofx files" do
+  it "uses 102 parser to parse version 102 ofx files" do
     expect(OFX::Parser::OFX102).to receive(:new).and_return('ofx-102-parser')
 
     ofx = OFX::Parser::Base.new(ofx_example_to('102'))
     expect(ofx.parser).to eql 'ofx-102-parser'
   end
 
-  it "should use 102 parser to parse version 103 ofx files" do
+  it "uses 102 parser to parse version 103 ofx files" do
     expect(OFX::Parser::OFX102).to receive(:new).and_return('ofx-102-parser')
 
     ofx = OFX::Parser::Base.new(ofx_example_to('103'))
     expect(ofx.parser).to eql 'ofx-102-parser'
   end
 
-  it "should use 211 parser to parse version 200 ofx files" do
+  it "uses 211 parser to parse version 200 ofx files" do
     allow(OFX::Parser::OFX211).to receive(:new).and_return('ofx-211-parser')
     ofx = OFX::Parser::Base.new(ofx_example_to('200'))
     expect(ofx.parser).to eql 'ofx-211-parser'
   end
 
-  it "should use 211 parser to parse version 202 ofx files" do
+  it "uses 211 parser to parse version 202 ofx files" do
     allow(OFX::Parser::OFX211).to receive(:new).and_return('ofx-211-parser')
     ofx = OFX::Parser::Base.new(ofx_example_to('202'))
     expect(ofx.parser).to eql 'ofx-211-parser'
   end
 
-  it "should use 211 parser to parse version 211 ofx files" do
+  it "uses 211 parser to parse version 211 ofx files" do
     allow(OFX::Parser::OFX211).to receive(:new).and_return('ofx-211-parser')
     ofx = OFX::Parser::Base.new(ofx_example_to('211'))
     expect(ofx.parser).to eql 'ofx-211-parser'
   end
 
-  it "should use 211 parser to parse version 220 ofx files" do
+  it "uses 211 parser to parse version 220 ofx files" do
     expect(OFX::Parser::OFX211).to receive(:new).and_return('ofx-211-parser')
 
     ofx = OFX::Parser::Base.new(ofx_example_to('220'))
@@ -105,47 +105,47 @@ describe OFX::Parser do
   end
 
   describe "headers" do
-    it "should have OFXHEADER" do
+    it "has OFXHEADER" do
       expect(@ofx.headers["OFXHEADER"]).to eql "100"
     end
 
-    it "should have DATA" do
+    it "has DATA" do
       expect(@ofx.headers["DATA"]).to eql "OFXSGML"
     end
 
-    it "should have VERSION" do
+    it "has VERSION" do
       expect(@ofx.headers["VERSION"]).to eql "102"
     end
 
-    it "should have SECURITY" do
+    it "has SECURITY" do
       expect(@ofx.headers).to have_key("SECURITY")
       expect(@ofx.headers["SECURITY"]).to be_nil
     end
 
-    it "should have ENCODING" do
+    it "has ENCODING" do
       expect(@ofx.headers["ENCODING"]).to eql "USASCII"
     end
 
-    it "should have CHARSET" do
+    it "has CHARSET" do
       expect(@ofx.headers["CHARSET"]).to eql "1252"
     end
 
-    it "should have COMPRESSION" do
+    it "has COMPRESSION" do
       expect(@ofx.headers).to have_key("COMPRESSION")
       expect(@ofx.headers["COMPRESSION"]).to be_nil
     end
 
-    it "should have OLDFILEUID" do
+    it "has OLDFILEUID" do
       expect(@ofx.headers).to have_key("OLDFILEUID")
       expect(@ofx.headers["OLDFILEUID"]).to be_nil
     end
 
-    it "should have NEWFILEUID" do
+    it "has NEWFILEUID" do
       expect(@ofx.headers).to have_key("NEWFILEUID")
       expect(@ofx.headers["NEWFILEUID"]).to be_nil
     end
 
-    it "should parse headers with CR and without LF" do
+    it "parses headers with CR and without LF" do
       header = %{OFXHEADER:100\rDATA:OFXSGML\rVERSION:102\rSECURITY:NONE\rENCODING:USASCII\rCHARSET:1252\rCOMPRESSION:NONE\rOLDFILEUID:NONE\rNEWFILEUID:NONE\r}
       body   = open("spec/fixtures/sample.ofx").read.split(/<OFX>/, 2)[1]
       ofx_with_carriage_return = header + "<OFX>" + body

--- a/spec/ofx/ofx_spec.rb
+++ b/spec/ofx/ofx_spec.rb
@@ -2,13 +2,13 @@ require "spec_helper"
 
 describe OFX do
   describe "#OFX" do
-    it "should yield an OFX instance" do
+    it "yields an OFX instance" do
       OFX("spec/fixtures/sample.ofx") do |ofx|
         expect(ofx.class).to eql OFX::Parser::OFX102
       end
     end
 
-    it "should be an OFX instance" do
+    it "is an OFX instance" do
       klass = nil
       OFX("spec/fixtures/sample.ofx") do
         klass = self.class
@@ -16,7 +16,7 @@ describe OFX do
       expect(klass).to eql OFX::Parser::OFX102
     end
 
-    it "should return parser" do
+    it "returns parser" do
       expect(OFX("spec/fixtures/sample.ofx").class).to eql OFX::Parser::OFX102
     end
   end

--- a/spec/ofx/sign_on_spec.rb
+++ b/spec/ofx/sign_on_spec.rb
@@ -8,19 +8,19 @@ describe OFX::SignOn do
   end
 
   describe "sign_on" do
-    it "should return language" do
+    it "returns language" do
       expect(@sign_on.language).to eql "ENG"
     end
 
-    it "should return Financial Institution ID" do
+    it "returns Financial Institution ID" do
       expect(@sign_on.fi_id).to eql "24909"
     end
 
-    it "should return Financial Institution Name" do
+    it "returns Financial Institution Name" do
       expect(@sign_on.fi_name).to eql "Citigroup"
     end
 
-    it "should return status" do
+    it "returns status" do
       expect(@sign_on.status).to be_a(OFX::Status)
     end
   end

--- a/spec/ofx/status_spec.rb
+++ b/spec/ofx/status_spec.rb
@@ -8,19 +8,19 @@ describe OFX::Status do
   context "success" do
     let(:ofx_file) { "spec/fixtures/creditcard.ofx" }
 
-    it "should return code" do
+    it "returns code" do
       expect(status.code).to eql 0
     end
 
-    it "should return severity" do
+    it "returns severity" do
       expect(status.severity).to eql :info
     end
 
-    it "should return message" do
+    it "returns message" do
       expect(status.message).to eql ""
     end
 
-    it "should be successful" do
+    it "is successful" do
       expect(status.success?).to eql true
     end
   end
@@ -28,19 +28,19 @@ describe OFX::Status do
   context "error" do
     let(:ofx_file) { "spec/fixtures/error.ofx" }
 
-    it "should return code" do
+    it "returns code" do
       expect(status.code).to eql 2000
     end
 
-    it "should return severity" do
+    it "returns severity" do
       expect(status.severity).to eql :error
     end
 
-    it "should return message" do
+    it "returns message" do
       expect(status.message).to eql "We were unable to process your request. Please try again later."
     end
 
-    it "should not be successful" do
+    it "is not successful" do
       expect(status.success?).to eql false
     end
   end

--- a/spec/ofx/transaction_spec.rb
+++ b/spec/ofx/transaction_spec.rb
@@ -12,43 +12,43 @@ describe OFX::Transaction do
       @transaction = @account.transactions[0]
     end
 
-    it "should set amount" do
+    it "sets amount" do
       expect(@transaction.amount).to eql BigDecimal('-35.34')
     end
 
-    it "should cast amount to BigDecimal" do
+    it "casts amount to BigDecimal" do
       expect(@transaction.amount.class).to be BigDecimal
     end
 
-    it "should set amount in pennies" do
+    it "sets amount in pennies" do
       expect(@transaction.amount_in_pennies).to eql -3534
     end
 
-    it "should set fit id" do
+    it "sets fit id" do
       expect(@transaction.fit_id).to eql "200910091"
     end
 
-    it "should set memo" do
+    it "sets memo" do
       expect(@transaction.memo).to eql "COMPRA VISA ELECTRON"
     end
 
-    it "should set check number" do
+    it "sets check number" do
       expect(@transaction.check_number).to eql "0001223"
     end
 
-    it "should have date" do
+    it "has date" do
       expect(@transaction.posted_at).to eql Time.parse("2009-10-09 08:00:00 +0000")
     end
 
-    it 'should have user date' do
+    it 'has user date' do
       expect(@transaction.occurred_at).to eql Time.parse("2009-09-09 08:00:00 +0000")
     end
 
-    it "should have type" do
+    it "has type" do
       expect(@transaction.type).to eql :debit
     end
 
-    it "should have sic" do
+    it "has sic" do
       expect(@transaction.sic).to eql '5072'
     end
   end
@@ -58,39 +58,39 @@ describe OFX::Transaction do
       @transaction = @account.transactions[1]
     end
 
-    it "should set amount" do
+    it "sets amount" do
       expect(@transaction.amount).to eql BigDecimal('60.39')
     end
 
-    it "should set amount in pennies" do
+    it "sets amount in pennies" do
       expect(@transaction.amount_in_pennies).to eql 6039
     end
 
-    it "should set fit id" do
+    it "sets fit id" do
       expect(@transaction.fit_id).to eql "200910162"
     end
 
-    it "should set memo" do
+    it "sets memo" do
       expect(@transaction.memo).to eql "DEPOSITO POUP.CORRENTE"
     end
 
-    it "should set check number" do
+    it "sets check number" do
       expect(@transaction.check_number).to eql "0880136"
     end
 
-    it "should have date" do
+    it "has date" do
       expect(@transaction.posted_at).to eql Time.parse("2009-10-16 08:00:00 +0000")
     end
 
-    it "should have user date" do
+    it "has user date" do
       expect(@transaction.occurred_at).to eql Time.parse("2009-09-16 08:00:00 +0000")
     end
 
-    it "should have type" do
+    it "has type" do
       expect(@transaction.type).to eql :credit
     end
 
-    it "should have empty sic" do
+    it "has empty sic" do
       expect(@transaction.sic).to eql ''
     end
   end
@@ -100,27 +100,27 @@ describe OFX::Transaction do
       @transaction = @account.transactions[2]
     end
 
-    it "should set payee" do
+    it "sets payee" do
       expect(@transaction.payee).to eql "Pagto conta telefone"
     end
 
-    it "should set check number" do
+    it "sets check number" do
       expect(@transaction.check_number).to eql "000000101901"
     end
 
-    it "should have date" do
+    it "has date" do
       expect(@transaction.posted_at).to eql Time.parse("2009-10-19 12:00:00 -0300")
     end
 
-    it "should have user date" do
+    it "has user date" do
       expect(@transaction.occurred_at).to eql Time.parse("2009-10-17 12:00:00 -0300")
     end
 
-    it "should have type" do
+    it "has type" do
       expect(@transaction.type).to eql :other
     end
 
-    it "should have reference number" do
+    it "has reference number" do
       expect(@transaction.ref_number).to eql "101.901"
     end
   end
@@ -130,7 +130,7 @@ describe OFX::Transaction do
       @transaction = @account.transactions[3]
     end
 
-    it "should set name" do
+    it "sets name" do
       expect(@transaction.name).to eql "Pagto conta telefone"
     end
   end
@@ -142,22 +142,22 @@ describe OFX::Transaction do
       @account = @parser.account
     end
 
-    it "should return dep" do
+    it "returns dep" do
       @transaction = @account.transactions[9]
       expect(@transaction.type).to eql :dep
     end
 
-    it "should return xfer" do
+    it "returns xfer" do
       @transaction = @account.transactions[18]
       expect(@transaction.type).to eql :xfer
     end
 
-    it "should return cash" do
+    it "returns cash" do
       @transaction = @account.transactions[45]
       expect(@transaction.type).to eql :cash
     end
 
-    it "should return check" do
+    it "returns check" do
       @transaction = @account.transactions[0]
       expect(@transaction.type).to eql :check
     end
@@ -175,11 +175,11 @@ describe OFX::Transaction do
         @transaction = @account.transactions[0]
       end
 
-      it "should set amount" do
+      it "sets amount" do
         expect(@transaction.amount).to eql BigDecimal('-11.76')
       end
 
-      it "should set amount in pennies" do
+      it "sets amount in pennies" do
         expect(@transaction.amount_in_pennies).to eql -1176
       end
     end
@@ -189,11 +189,11 @@ describe OFX::Transaction do
         @transaction = @account.transactions[3]
       end
 
-      it "should set amount" do
+      it "sets amount" do
         expect(@transaction.amount).to eql BigDecimal('47.01')
       end
 
-      it "should set amount in pennies" do
+      it "sets amount in pennies" do
         expect(@transaction.amount_in_pennies).to eql 4701
       end
     end
@@ -205,15 +205,15 @@ describe OFX::Transaction do
       @parser = @ofx.parser
     end
 
-    it "should not raise error" do
+    it "does not raise error" do
       expect { @parser.account.transactions }.to_not raise_error
     end
 
-    it "should return zero in amount" do
+    it "returns zero in amount" do
       expect(@parser.account.transactions[0].amount).to eql BigDecimal('0.0')
     end
 
-    it "should return zero in amount_in_pennies" do
+    it "returns zero in amount_in_pennies" do
       expect(@parser.account.transactions[0].amount_in_pennies).to eql 0
     end
   end


### PR DESCRIPTION
Closes #131

## Summary

- PR #125 migrated RSpec assertions from `should` to `expect` syntax, but missed updating the `it "should ..."` description strings
- This PR completes that work by converting all descriptions to present tense (e.g. `"returns"`, `"sets"`, `"has"`, `"is"`) following the same style already present in `statement_spec.rb` and as referenced in PR #115

## Test plan

- [x] Run `bundle exec rspec` — all 141 examples pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)