### PR TITLE
chore: configure GitHub Actions matrix for Ruby 3.1, 3.2 and 3.3

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -3,15 +3,17 @@ on:
   push:
 
 jobs:
-  rspec:
+  test:
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.2', '3.3']
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-
-      - run: bundle exec rspec
+      - name: Run Tests
+        run: bundle exec rspec


### PR DESCRIPTION
## Summary

- Add matrix strategy to test against Ruby 3.1, 3.2 and 3.3
- Rename job from `rspec` to `test`
- Upgrade `actions/checkout` from v3 to v4

## Test plan

- [x] CI will run on push, triggering 3 parallel jobs (one per Ruby version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)