### PR TITLE
Support Ruby 3.4 default gem changes

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,16 @@ PATH
   remote: .
   specs:
     ofx (0.3.8)
+      bigdecimal
       erb (~> 4.0.4)
+      nkf
       nokogiri (>= 1.13.1, < 1.19.2)
       stringio (~> 3.1.7)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    bigdecimal (4.1.2)
     byebug (11.1.3)
     cgi (0.5.1)
     coderay (1.1.3)
@@ -44,6 +47,7 @@ GEM
     method_source (1.1.0)
     mini_portile2 (2.8.9)
     nenv (0.3.0)
+    nkf (0.3.0)
     nokogiri (1.18.10)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)

--- a/ofx.gemspec
+++ b/ofx.gemspec
@@ -26,11 +26,13 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1.0'
 
   s.add_dependency 'nokogiri', '>= 1.13.1', '< 1.19.2'
+  s.add_dependency 'bigdecimal'
   s.add_development_dependency 'byebug', '~> 11.1.3'
   s.add_development_dependency 'rake', '~> 13.0.6'
   s.add_development_dependency 'rspec', '~> 3.10'
   s.add_development_dependency 'guard', '~> 2.20'
   s.add_development_dependency 'guard-rspec', '~> 4.7'
   s.add_dependency 'erb', '~> 4.0.4'
+  s.add_dependency 'nkf'
   s.add_dependency 'stringio', '~> 3.1.7'
 end


### PR DESCRIPTION
## Summary

Add explicit runtime dependencies for Ruby standard-library components that are no longer guaranteed to ship as default gems, and exercise the library on Ruby 3.4 in CI.

## Changes

- Declare `bigdecimal` as a runtime dependency because the parser requires and uses `BigDecimal` for monetary values.
- Declare `nkf` as a runtime dependency because `kconv` is provided by that gem.
- Add Ruby 3.4 to the GitHub Actions test matrix.
- Refresh `Gemfile.lock` with the resolved `bigdecimal` and `nkf` versions while preserving the existing supported platforms.

## Why

Without these declarations, installing the gem on Ruby 3.4 can succeed while loading `ofx` later fails with `LoadError`. Making the dependencies explicit keeps the runtime contract accurate and lets CI detect future Ruby compatibility regressions.

## Verification

- Ruby 3.4.4
- `bundle exec rspec`
- 141 examples, 0 failures

Closes #113
Closes #133
