### PR TITLE
Make GitHub Actions reliable for pull requests

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -1,11 +1,25 @@
 name: Tests
+
 on:
   push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['3.1', '3.2', '3.3']
     steps:


### PR DESCRIPTION
## Summary

Make the test workflow run consistently for changes proposed through pull requests and make failures easier to diagnose and recover from.

## Findings

The current `main` workflow is passing. The failed checks still visible on open Dependabot PRs were produced by stale branches that carry the previous Ruby 2.7 workflow and obsolete dependency lockfiles. The current workflow also listens only to `push`, so contributors using forks do not receive a normal pull-request check and maintainers cannot run it manually.

## Changes

- Run the workflow for pushes to `main`.
- Run it for every pull request, including contributions from forks.
- Add `workflow_dispatch` so maintainers can rerun the suite manually.
- Restrict the workflow token to read-only repository contents.
- Cancel superseded runs for the same branch or pull request.
- Add a ten-minute job timeout to prevent stuck dependency installations from consuming runner time indefinitely.
- Disable matrix fail-fast so failures on one Ruby version do not hide results from the others.

## Verification

- Parsed `.github/workflows/config.yml` successfully as YAML.
- `bundle exec rspec`: 141 examples, 0 failures.
- `git diff --check`: clean.

## Follow-up for existing Dependabot PRs

After this change is merged, the currently stale Dependabot branches should be rebased or recreated. Their old failed runs are immutable, but new commits will use the maintained Ruby 3.1–3.3 workflow and produce current checks.
